### PR TITLE
Add reader example program

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ loading and unloading the module are provided.
 ## Installation & Prerequisites
 1. Ensure you have kernel headers and build tools installed. Update the
    `KERNELDIR` path inside `Makefile` if necessary.
-2. Compile the module and test program:
+2. Compile the module, the interactive test program and the simple reader:
    ```bash
    make            # builds encdec.o
    gcc test.c -o test
+   gcc reader.c -o reader
    ```
 3. (Optional) Set executable permission on helper scripts:
    ```bash
@@ -60,6 +61,19 @@ Common commands within the tester include:
   return raw bytes or decrypted text.
 - `write <fd_index> "text"` and `read <fd_index> <count>` – perform I/O.
 - `lseek <fd_index> <pos>` – set the file position.
+
+### Simple Reader Utility
+An additional example program `reader.c` is provided for quickly reading data
+from one of the encdec devices without using the interactive tester. Compile it
+with:
+```bash
+gcc reader.c -o reader
+```
+Example usage reading 20 decrypted bytes from `/dev/encdec0` using key `4`:
+```bash
+./reader /dev/encdec0 20 --key 4 --decrypt
+```
+It supports the `--raw` flag to read encrypted bytes instead.
 
 To unload the module and clean device nodes:
 ```bash

--- a/reader.c
+++ b/reader.c
@@ -1,0 +1,74 @@
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include "encdec.h"
+
+static void usage(const char *prog)
+{
+    fprintf(stderr, "Usage: %s <device> <count> [--key <value>] [--raw|--decrypt]\n", prog);
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc < 3) {
+        usage(argv[0]);
+        return 1;
+    }
+
+    const char *device = argv[1];
+    int count = atoi(argv[2]);
+    int key = 0;
+    int read_state = ENCDEC_READ_STATE_DECRYPT;
+
+    for (int i = 3; i < argc; ++i) {
+        if (strcmp(argv[i], "--key") == 0 && i + 1 < argc) {
+            key = atoi(argv[++i]);
+        } else if (strcmp(argv[i], "--raw") == 0) {
+            read_state = ENCDEC_READ_STATE_RAW;
+        } else if (strcmp(argv[i], "--decrypt") == 0) {
+            read_state = ENCDEC_READ_STATE_DECRYPT;
+        } else {
+            usage(argv[0]);
+            return 1;
+        }
+    }
+
+    int fd = open(device, O_RDONLY);
+    if (fd < 0) {
+        perror("open");
+        return 1;
+    }
+
+    if (ioctl(fd, ENCDEC_CMD_CHANGE_KEY, key) < 0) {
+        perror("ioctl change_key");
+    }
+
+    if (ioctl(fd, ENCDEC_CMD_SET_READ_STATE, read_state) < 0) {
+        perror("ioctl set_read_state");
+    }
+
+    char *buf = malloc(count + 1);
+    if (!buf) {
+        perror("malloc");
+        close(fd);
+        return 1;
+    }
+
+    int ret = read(fd, buf, count);
+    if (ret < 0) {
+        perror("read");
+        free(buf);
+        close(fd);
+        return 1;
+    }
+
+    buf[ret] = '\0';
+    printf("%s", buf);
+
+    free(buf);
+    close(fd);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a new `reader.c` utility for reading from the encdec devices
- document how to build and use the reader in README

## Testing
- `gcc reader.c -o reader`
- `gcc test.c -o test_new`
- `./test_new < test1.in` *(fails: Bad file descriptor because module isn't loaded)*
- `./reader /dev/null 0` *(fails: Inappropriate ioctl for device)*

------
https://chatgpt.com/codex/tasks/task_e_687bce18312083329cc11364a941fe6f